### PR TITLE
Fix rendering artifacts

### DIFF
--- a/src/renderer/path.js
+++ b/src/renderer/path.js
@@ -79,7 +79,9 @@ Kothic.path = (function () {
             len = coords.length,
             len2, pointsLen,
             prevPoint, point, screenPoint,
-            dx, dy, dist, pad = 50;
+            dx, dy, dist,
+            pad = 50, // how many pixels to draw out of the tile to avoid path edges when lines crosses tile borders
+            skip = 2; // do not draw line segments shorter than this
 
         if (type === "MultiPolygon") {
             for (i = 0; i < len; i++) {
@@ -118,11 +120,23 @@ Kothic.path = (function () {
 
                     // continue path off the tile by some abount to fix path edges between tiles
                     if ((j === 0 || j === pointsLen - 1) && isTileBoundary(point, granularity)) {
-                        prevPoint = points[j ? pointsLen - 2 : 1];
+                        k = j;
+                        do {
+                            k = j ? k - 1 : k + 1;
+                            if (k < 0 || k >= pointsLen)
+                                break;
+                            prevPoint = points[k];
 
-                        dx = point[0] - prevPoint[0];
-                        dy = point[1] - prevPoint[1];
-                        dist = Math.sqrt(dx * dx + dy * dy);
+                            dx = point[0] - prevPoint[0];
+                            dy = point[1] - prevPoint[1];
+                            dist = Math.sqrt(dx * dx + dy * dy);
+                        } while (dist <= skip);
+
+                        // all points are so close to each other that it doesn't make sense to
+                        // draw the line beyond the tile border, simply skip the entire line from
+                        // here
+                        if (k < 0 || k >= pointsLen)
+                            break;
 
                         screenPoint[0] = screenPoint[0] + pad * dx / dist;
                         screenPoint[1] = screenPoint[1] + pad * dy / dist;

--- a/src/renderer/path.js
+++ b/src/renderer/path.js
@@ -116,7 +116,6 @@ Kothic.path = (function () {
 
                 for (j = 0; j < pointsLen; j++) {
                     point = points[j];
-                    screenPoint = Kothic.geom.transformPoint(point, ws, hs);
 
                     // continue path off the tile by some abount to fix path edges between tiles
                     if ((j === 0 || j === pointsLen - 1) && isTileBoundary(point, granularity)) {
@@ -138,9 +137,10 @@ Kothic.path = (function () {
                         if (k < 0 || k >= pointsLen)
                             break;
 
-                        screenPoint[0] = screenPoint[0] + pad * dx / dist;
-                        screenPoint[1] = screenPoint[1] + pad * dy / dist;
+                        point[0] = point[0] + pad * dx / dist;
+                        point[1] = point[1] + pad * dy / dist;
                     }
+                    screenPoint = Kothic.geom.transformPoint(point, ws, hs);
 
                     if (j === 0) {
                         moveTo(ctx, screenPoint, dashes);

--- a/src/renderer/path.js
+++ b/src/renderer/path.js
@@ -67,9 +67,7 @@ Kothic.path = (function () {
         if (type === "Polygon") {
             coords = [coords];
             type = "MultiPolygon";
-        }
-
-        if (type === "LineString") {
+        } else if (type === "LineString") {
             coords = [coords];
             type = "MultiLineString";
         }
@@ -79,9 +77,7 @@ Kothic.path = (function () {
             len = coords.length,
             len2, pointsLen,
             prevPoint, point, screenPoint,
-            dx, dy, dist,
-            pad = 50, // how many pixels to draw out of the tile to avoid path edges when lines crosses tile borders
-            skip = 2; // do not draw line segments shorter than this
+            dx, dy, dist;
 
         if (type === "MultiPolygon") {
             for (i = 0; i < len; i++) {
@@ -107,9 +103,10 @@ Kothic.path = (function () {
                     }
                 }
             }
-        }
+        } else if (type === "MultiLineString") {
+            var pad = 50, // how many pixels to draw out of the tile to avoid path edges when lines crosses tile borders
+                skip = 2; // do not draw line segments shorter than this
 
-        if (type === "MultiLineString") {
             for (i = 0; i < len; i++) {
                 points = coords[i];
                 pointsLen = points.length;


### PR DESCRIPTION
These artifacts were reported in [#11 of node-tileserver](https://github.com/rurseekatze/node-tileserver/issues/11) and have been fixed there. We have not seen these artifacts or any regressions since then. See the patches for analysis of the single issues.