### PR TITLE
Add support for additional font properties

### DIFF
--- a/src/renderer/shields.js
+++ b/src/renderer/shields.js
@@ -19,7 +19,7 @@ Kothic.shields = {
         }
 
         Kothic.style.setStyles(ctx, {
-            font: Kothic.style.getFontString(style["shield-font-family"] || style["font-family"], style["shield-font-size"] || style["font-size"]),
+            font: Kothic.style.getFontString(style["shield-font-family"] || style["font-family"], style["shield-font-size"] || style["font-size"], style),
             fillStyle: style["shield-text-color"] || "#000000",
             globalAlpha: style["shield-text-opacity"] || style.opacity || 1,
             textAlign: 'center',

--- a/src/renderer/texticons.js
+++ b/src/renderer/texticons.js
@@ -40,7 +40,7 @@ Kothic.texticons = {
         if (renderText) {
             Kothic.style.setStyles(ctx, {
                 lineWidth: style['text-halo-radius'] * 2,
-                font: Kothic.style.getFontString(style['font-family'], style['font-size'])
+                font: Kothic.style.getFontString(style['font-family'], style['font-size'], style)
             });
 
             var text = String(style.text);

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -82,7 +82,7 @@ Kothic.style = {
         return styledFeatures;
     },
 
-    getFontString: function (name, size) {
+    getFontString: function (name, size, st) {
         name = name || '';
         size = size || 9;
 
@@ -91,12 +91,14 @@ Kothic.style = {
         name = name.toLowerCase();
 
         var styles = [];
-        if (name.indexOf('italic') !== -1 || name.indexOf('oblique') !== -1) {
+        if (st['font-style'] == 'italic' || name.indexOf('italic') !== -1 || name.indexOf('oblique') !== -1) {
             styles.push('italic');
         }
-        if (name.indexOf('bold') !== -1) {
+        if (st['font-variant'] == 'small-caps') {
+            styles.push('small-caps');
+        }
+        if (st['font-weight'] == 'bold' || name.indexOf('bold') !== -1) {
             styles.push('bold');
-            //family += '''+name.replace('bold', '')+'', ';
             family += name.replace('bold', '') + ', ';
         }
 
@@ -108,7 +110,6 @@ Kothic.style = {
             family += '"Helvetica Neue", Arial, Helvetica, sans-serif';
         }
         styles.push(family);
-
 
         return styles.join(' ');
     },

--- a/src/style/style.js
+++ b/src/style/style.js
@@ -91,15 +91,14 @@ Kothic.style = {
         name = name.toLowerCase();
 
         var styles = [];
-        if (st['font-style'] == 'italic' || name.indexOf('italic') !== -1 || name.indexOf('oblique') !== -1) {
+        if (st['font-style'] == 'italic') {
             styles.push('italic');
         }
         if (st['font-variant'] == 'small-caps') {
             styles.push('small-caps');
         }
-        if (st['font-weight'] == 'bold' || name.indexOf('bold') !== -1) {
+        if (st['font-weight'] == 'bold') {
             styles.push('bold');
-            family += name.replace('bold', '') + ', ';
         }
 
         styles.push(size + 'px');


### PR DESCRIPTION
This reworks the way the font handling works from autodetecting the style from the font name to requiring the user to explicitely specify it using font-weight, font-variant, or font-style. This is a change in behavior, therefore the request for review.