### PR TITLE
scan layers only once for features

### DIFF
--- a/src/kothic.js
+++ b/src/kothic.js
@@ -113,7 +113,6 @@ var Kothic = {
         var layersToRender = {},
             i, j, len, features, style, queue, bgQueue;
 
-        // polygons
         for (i = 0; i < layerIds.length; i++) {
             features = layers[layerIds[i]];
 
@@ -132,31 +131,13 @@ var Kothic = {
                         queue.polygons.push(features[j]);
                     }
                 }
-            }
-        }
 
-        // casings
-        for (i = 0; i < layerIds.length; i++) {
-            features = layers[layerIds[i]];
-            queue = layersToRender[layerIds[i]] = layersToRender[layerIds[i]] || {};
-
-            for (j = 0, len = features.length; j < len; j++) {
-
-                if ('casing-width' in features[j].style) {
+                if ('casing-width' in style) {
                     queue.casings = queue.casings || [];
                     queue.casings.push(features[j]);
                 }
-            }
-        }
 
-        // lines
-        for (i = 0; i < layerIds.length; i++) {
-            features = layers[layerIds[i]];
-            queue = layersToRender[layerIds[i]] = layersToRender[layerIds[i]] || {};
-
-            for (j = 0, len = features.length; j < len; j++) {
-
-                if ('width' in features[j].style) {
+                if ('width' in style) {
                     queue.lines = queue.lines || [];
                     queue.lines.push(features[j]);
                 }


### PR DESCRIPTION
The layers are only scanned here and the features are collected in arrays, so it does not matter if e.g. casings are scanned before polygons. The order inside the arrays is kept stable.

I can see no visible difference with or without this patch, and from code inspection it looks like it should be equivalent. I'm just not sure why it wasn't done this way already, maybe it was just an oversight in cdb1121f.