### PR TITLE
Wait for images to load before rendering

### DIFF
--- a/src/kothic.js
+++ b/src/kothic.js
@@ -8,6 +8,11 @@ var Kothic = {
 
     render: function (canvas, data, zoom, options) {
 
+        if(!MapCSS.imagesLoaded) {
+            MapCSS.renderQueue.push(Kothic.render.bind(this, canvas, data, zoom, options));
+            return;
+        }
+
         if (typeof canvas === 'string') {
             canvas = document.getElementById(canvas);
         }

--- a/src/style/mapcss.js
+++ b/src/style/mapcss.js
@@ -8,11 +8,18 @@ var MapCSS = {
     value_tags: [],
     cache: {},
     debug: {hit: 0, miss: 0},
+    renderQueue: [],
+    imagesLoaded: false,
 
     onError: function () {
     },
 
     onImagesLoad: function () {
+        MapCSS.imagesLoaded = true;
+        MapCSS.renderQueue.forEach(function(renderCall) {
+            renderCall();
+        });
+        MapCSS.renderQueue = [];
     },
 
     /**


### PR DESCRIPTION
Currently, rendering of features with icons sometimes does not happen, because the rendering is attempted before all images have fully loaded. This PR sets an 'imagesLoaded' flag when all images have loaded, and checks for this flag when rendering. If the flag is false, the current Kothic.render() call is added to a rendering queue (actually, an array). Then, when image load is complete, all render() calls on the queue are called.
