### PR TITLE
feat(leaflet): add clickable point layer

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,7 +41,7 @@ module.exports = function (grunt) {
                 browser: true
             },
             all: {
-                src: ['Gruntfile.js', 'src/**/*.js', 'dist/kothic-leaflet.js', '!src/utils/rbush.js']
+                src: ['Gruntfile.js', 'src/**/*.js', 'dist/kothic-leaflet*.js', '!src/utils/rbush.js']
             }
         },
 

--- a/dist/kothic-leaflet-clickable.js
+++ b/dist/kothic-leaflet-clickable.js
@@ -1,0 +1,105 @@
+L.TileLayer.Kothic.Clickable = L.TileLayer.Kothic.extend({
+    options: {
+        pixelThreshold: 10
+    },
+
+    initialize: function(url, options) {
+        this._data = {};
+        L.TileLayer.Kothic.prototype.initialize.call(this, url, options);
+    },
+
+    onAdd: function(map) {
+        this._clickHandler = L.Util.bind(this._onclick, this);
+        map.on('click', this._clickHandler);
+        L.GridLayer.prototype.onAdd.call(this, map);
+    },
+
+    onRemove: function(map) {
+        if (this._clickHandler) {
+            map.off('click', this._clickHandler);
+            delete this._clickHandler;
+        }
+        this._data = {};
+        L.GridLayer.prototype.onRemove.call(this, map);
+    },
+
+    _onclick: function(e) {
+        var tileClickPos = this._map.project(e.latlng),
+            tileSize = this.options.tileSize,
+            tileX = Math.floor(tileClickPos.x / tileSize),
+            tileY = Math.floor(tileClickPos.y / tileSize),
+            key = [this._map.getZoom() - this.options.zoomOffset, tileX, tileY].join('/'),
+            data = this._data[key],
+            pixelsToKothicUnits,
+            dataX,
+            dataY,
+            threshold,
+            lowest = Number.MAX_VALUE,
+            nearestFeature = null,
+            i,
+            dx,
+            dy,
+            dist,
+            featLatLng;
+
+        if (!data || !data.features.length) {
+            return;
+        }
+
+        pixelsToKothicUnits = data.granularity / tileSize;
+        tileClickPos.x %= tileSize;
+        tileClickPos.y %= tileSize;
+        dataX = tileClickPos.x * pixelsToKothicUnits;
+        dataY = tileClickPos.y * pixelsToKothicUnits;
+        threshold = this.options.pixelThreshold * pixelsToKothicUnits;
+
+        for (i = 0; i < data.features.length; i++) {
+            dx = Math.abs(data.features[i].coordinates[0] - dataX);
+            dy = Math.abs(data.features[i].coordinates[1] - dataY);
+            if (dx < threshold && dy < threshold) {
+                dist = Math.sqrt(dx * dx + dy * dy);
+                if (dist < lowest) {
+                    lowest = dist;
+                    nearestFeature = data.features[i];
+                }
+            }
+        }
+
+        if (nearestFeature !== null) {
+            featLatLng = this._map.unproject(new L.Point(
+                tileX * tileSize + nearestFeature.coordinates[0] / pixelsToKothicUnits,
+                tileY * tileSize + nearestFeature.coordinates[1] / pixelsToKothicUnits
+            ));
+
+            this.fire('featureclick', {
+                latlng: featLatLng,
+                feature: nearestFeature
+            });
+        }
+    },
+
+    _onKothicDataResponse: function(data, zoom, x, y, done) {
+        var key = [zoom, x, y].join('/'),
+            stored = {
+                granularity: data.granularity,
+                features: []
+            },
+            i;
+
+        if (!this._canvases[key]) {
+            L.TileLayer.Kothic.prototype._onKothicDataResponse.call(this, data, zoom, x, y, done);
+            return;
+        }
+
+        L.TileLayer.Kothic.prototype._onKothicDataResponse.call(this, data, zoom, x, y, done);
+
+        if (!this._data[key]) {
+            for (i = 0; i < data.features.length; i++) {
+                if (data.features[i].type === 'Point') {
+                    stored.features.push(data.features[i]);
+                }
+            }
+            this._data[key] = stored;
+        }
+    }
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "grunt-contrib-uglify": "^4.0.1"
   },
   "scripts": {
-    "prepublish": "grunt"
+    "prepublish": "grunt",
+    "test": "grunt && node tests/clickable-layer-test.js"
   }
 }

--- a/tests/clickable-layer-test.js
+++ b/tests/clickable-layer-test.js
@@ -1,0 +1,191 @@
+/* eslint-env node */
+'use strict';
+
+var assert = require('assert'),
+    fs = require('fs'),
+    vm = require('vm');
+
+function extend(props) {
+    var Parent = this;
+
+    function Child() {
+        if (this.initialize) {
+            this.initialize.apply(this, arguments);
+        }
+    }
+
+    Child.prototype = Object.create(Parent.prototype);
+    Child.prototype.constructor = Child;
+    Object.keys(props).forEach(function(key) {
+        Child.prototype[key] = props[key];
+    });
+    Child.extend = extend;
+    return Child;
+}
+
+function createContext() {
+    var events = [],
+        context = {
+            console: console,
+            window: null,
+            MapCSS: {
+                availableStyles: [],
+                invalidateCache: function() {}
+            },
+            Kothic: {
+                render: function(canvas, data, zoom, options) {
+                    if (options && options.onRenderComplete) {
+                        options.onRenderComplete();
+                    }
+                }
+            },
+            L: {
+                Util: {
+                    setOptions: function(obj, options) {
+                        obj.options = Object.assign(
+                            {},
+                            Object.getPrototypeOf(obj).options || {},
+                            options || {}
+                        );
+                    },
+                    bind: function(fn, obj) {
+                        return fn.bind(obj);
+                    }
+                },
+                Point: function Point(x, y) {
+                    this.x = x;
+                    this.y = y;
+                },
+                DomUtil: {
+                    create: function() {
+                        return {};
+                    }
+                },
+                GridLayer: function GridLayer() {},
+                TileLayer: {}
+            }
+        };
+
+    context.window = context;
+    context.L.GridLayer.prototype = {
+        onAdd: function(map) {
+            this._map = map;
+        },
+        onRemove: function() {
+            delete this._map;
+        },
+        fire: function(name, payload) {
+            events.push({
+                name: name,
+                payload: payload
+            });
+        }
+    };
+    context.L.GridLayer.extend = extend;
+    context.events = events;
+
+    vm.createContext(context);
+    vm.runInContext(fs.readFileSync('dist/kothic-leaflet.js', 'utf8'), context, {
+        filename: 'dist/kothic-leaflet.js'
+    });
+    vm.runInContext(fs.readFileSync('dist/kothic-leaflet-clickable.js', 'utf8'), context, {
+        filename: 'dist/kothic-leaflet-clickable.js'
+    });
+
+    return context;
+}
+
+function createMap(pixel) {
+    return {
+        handlers: {},
+        removedHandlers: {},
+        on: function(name, handler) {
+            this.handlers[name] = handler;
+        },
+        off: function(name, handler) {
+            this.removedHandlers[name] = handler;
+            delete this.handlers[name];
+        },
+        getZoom: function() {
+            return 13;
+        },
+        project: function() {
+            return {
+                x: pixel.x,
+                y: pixel.y
+            };
+        },
+        unproject: function(point) {
+            return {
+                lat: point.y,
+                lng: point.x
+            };
+        }
+    };
+}
+
+function runTests() {
+    var context = createContext(),
+        Layer = context.L.TileLayer.Kothic.Clickable,
+        layer = new Layer('/{z}/{x}/{y}.json', {
+            tileSize: 256,
+            zoomOffset: 0
+        }),
+        map = createMap({
+            x: 2 * 256 + 25,
+            y: 3 * 256 + 51
+        }),
+        clickHandler;
+
+    layer.onAdd(map);
+    assert.strictEqual(typeof map.handlers.click, 'function');
+    clickHandler = map.handlers.click;
+
+    assert.doesNotThrow(function() {
+        map.handlers.click({
+            latlng: {}
+        });
+    });
+    assert.strictEqual(context.events.length, 0);
+
+    layer._canvases['13/2/3'] = {};
+    layer._onKothicDataResponse({
+        granularity: 10000,
+        features: [
+            {
+                id: 'near',
+                type: 'Point',
+                coordinates: [976.5625, 8007.8125]
+            },
+            {
+                id: 'line',
+                type: 'LineString',
+                coordinates: [[0, 0], [1, 1]]
+            },
+            {
+                id: 'far',
+                type: 'Point',
+                coordinates: [5000, 5000]
+            }
+        ]
+    }, 13, 2, 3, function done() {});
+
+    map.handlers.click({
+        latlng: {}
+    });
+
+    assert.strictEqual(context.events.length, 1);
+    assert.strictEqual(context.events[0].name, 'featureclick');
+    assert.strictEqual(context.events[0].payload.feature.id, 'near');
+    assert.deepStrictEqual(context.events[0].payload.latlng, {
+        lat: 819,
+        lng: 537
+    });
+
+    layer.onRemove(map);
+    assert.strictEqual(map.handlers.click, undefined);
+    assert.strictEqual(map.removedHandlers.click, clickHandler);
+    assert.deepStrictEqual(Object.keys(layer._data), []);
+}
+
+runTests();


### PR DESCRIPTION
Replacement for #71. This keeps the clickable POI idea, but ports it to the current Leaflet integration instead of merging the old dist-only patch as-is.

What changed:
- add `L.TileLayer.Kothic.Clickable`, extending the current `L.GridLayer`-based Kothic layer
- fire `featureclick` with the nearest point feature within `pixelThreshold` pixels
- ignore clicks on tiles whose Kothic data has not loaded yet
- pass the current GridLayer `done` callback through to the parent renderer
- unregister the map click handler and clear cached tile feature data on remove
- keep `.gitignore` unchanged, so generated `dist/kothic.js` / `dist/kothic.min.js` stay ignored
- add a small Node smoke test that loads the real leaflet layer and clickable layer, checks unloaded-tile clicks, emitted feature data, and handler cleanup

Validation:
- `npm test`
- `git diff --check`

Notes:
- This intentionally supersedes #71 rather than merging it, because #71 targets the old `L.TileLayer.Canvas` API and does not pass the current `done` callback.