### PR TITLE
fix(debug): make tile demo self-contained

### DIFF
--- a/debug/test-tile.js
+++ b/debug/test-tile.js
@@ -1,0 +1,28 @@
+var tile_zoom = 13;
+var tile_data = {
+    "granularity": 10000,
+    "features": [
+        {
+            "type": "Polygon",
+            "properties": {
+                "natural": "coastline"
+            },
+            "coordinates": [[[0, 0], [0, 10000], [10000, 10000], [10000, 0], [0, 0]]]
+        },
+        {
+            "type": "LineString",
+            "properties": {
+                "highway": "residential",
+                "name": "Debug Street"
+            },
+            "coordinates": [[1200, 5000], [8800, 5000]]
+        },
+        {
+            "type": "Polygon",
+            "properties": {
+                "building": "yes"
+            },
+            "coordinates": [[[4500, 4300], [5600, 4300], [5600, 5400], [4500, 5400], [4500, 4300]]]
+        }
+    ]
+};

--- a/debug/tile.html
+++ b/debug/tile.html
@@ -15,16 +15,18 @@
 	<canvas id="map" width="1024" height="1024"></canvas>
 
 	<script type="text/javascript">
+        var onImagesLoad = MapCSS.onImagesLoad;
 
         invertYAxe(tile_data);
 
         MapCSS.onImagesLoad = function () {
+            onImagesLoad();
             Kothic.render('map', tile_data, tile_zoom, {
                 styles: ['osmosnimki']
             });
         };
 
-        MapCSS.preloadSpriteImage("osmosnimki", "http://toolserver.org/~osm/kothic/osmosnimki.png");
+        MapCSS.preloadSpriteImage("osmosnimki", "styles/osmosnimki.png");
 
         function invertYAxe(data) {
             var type, coordinates, tileSize = data.granularity, i, j, k, l, feature;


### PR DESCRIPTION
Replacement for #75. The old PR moved the demo to `fetch("test-tile.json")`, which works from a local HTTP server but still fails when opening `debug/tile.html` directly as a local file.

What changed:
- restore the missing `debug/test-tile.js` fixture expected by `tile.html`, using a small self-contained tile instead of duplicating the large JSON fixture
- load the checked-in local `styles/osmosnimki.png` sprite instead of the dead `toolserver.org` URL
- preserve the original `MapCSS.onImagesLoad` behavior before rendering, so Kothic does not leave the render queued forever

Validation:
- `npm test`
- `git diff --check`
- Playwright/Chromium smoke: `file://.../debug/tile.html` renders a nonblank canvas with no page errors
- Playwright/Chromium smoke: `http://127.0.0.1/.../debug/tile.html` renders a nonblank canvas with no page errors

Notes:
- This intentionally supersedes #75 rather than merging it as-is.