### PR TITLE
fix(leaflet): evict clickable tile cache

### DIFF
--- a/dist/kothic-leaflet-clickable.js
+++ b/dist/kothic-leaflet-clickable.js
@@ -10,7 +10,9 @@ L.TileLayer.Kothic.Clickable = L.TileLayer.Kothic.extend({
 
     onAdd: function(map) {
         this._clickHandler = L.Util.bind(this._onclick, this);
+        this._tileUnloadHandler = L.Util.bind(this._onTileUnload, this);
         map.on('click', this._clickHandler);
+        this.on('tileunload', this._tileUnloadHandler);
         L.GridLayer.prototype.onAdd.call(this, map);
     },
 
@@ -18,6 +20,10 @@ L.TileLayer.Kothic.Clickable = L.TileLayer.Kothic.extend({
         if (this._clickHandler) {
             map.off('click', this._clickHandler);
             delete this._clickHandler;
+        }
+        if (this._tileUnloadHandler) {
+            this.off('tileunload', this._tileUnloadHandler);
+            delete this._tileUnloadHandler;
         }
         this._data = {};
         L.GridLayer.prototype.onRemove.call(this, map);
@@ -76,6 +82,13 @@ L.TileLayer.Kothic.Clickable = L.TileLayer.Kothic.extend({
                 feature: nearestFeature
             });
         }
+    },
+
+    _onTileUnload: function(e) {
+        var coords = e.coords,
+            key = [coords.z - this.options.zoomOffset, coords.x, coords.y].join('/');
+
+        delete this._data[key];
     },
 
     _onKothicDataResponse: function(data, zoom, x, y, done) {

--- a/tests/clickable-layer-test.js
+++ b/tests/clickable-layer-test.js
@@ -68,6 +68,15 @@ function createContext() {
 
     context.window = context;
     context.L.GridLayer.prototype = {
+        on: function(name, handler) {
+            this._layerHandlers = this._layerHandlers || {};
+            this._layerHandlers[name] = handler;
+        },
+        off: function(name, handler) {
+            this._removedLayerHandlers = this._removedLayerHandlers || {};
+            this._removedLayerHandlers[name] = handler;
+            delete this._layerHandlers[name];
+        },
         onAdd: function(map) {
             this._map = map;
         },
@@ -135,11 +144,14 @@ function runTests() {
             x: 2 * 256 + 25,
             y: 3 * 256 + 51
         }),
-        clickHandler;
+        clickHandler,
+        tileUnloadHandler;
 
     layer.onAdd(map);
     assert.strictEqual(typeof map.handlers.click, 'function');
     clickHandler = map.handlers.click;
+    assert.strictEqual(typeof layer._layerHandlers.tileunload, 'function');
+    tileUnloadHandler = layer._layerHandlers.tileunload;
 
     assert.doesNotThrow(function() {
         map.handlers.click({
@@ -181,10 +193,34 @@ function runTests() {
         lat: 819,
         lng: 537
     });
+    assert.strictEqual(layer._data['13/2/3'].features.length, 2);
+
+    layer._layerHandlers.tileunload({
+        coords: {
+            z: 13,
+            x: 2,
+            y: 3
+        }
+    });
+    assert.strictEqual(layer._data['13/2/3'], undefined);
+
+    layer._canvases['13/2/3'] = {};
+    layer._onKothicDataResponse({
+        granularity: 10000,
+        features: [
+            {
+                id: 'near',
+                type: 'Point',
+                coordinates: [976.5625, 8007.8125]
+            }
+        ]
+    }, 13, 2, 3, function done() {});
 
     layer.onRemove(map);
     assert.strictEqual(map.handlers.click, undefined);
     assert.strictEqual(map.removedHandlers.click, clickHandler);
+    assert.strictEqual(layer._layerHandlers.tileunload, undefined);
+    assert.strictEqual(layer._removedLayerHandlers.tileunload, tileUnloadHandler);
     assert.deepStrictEqual(Object.keys(layer._data), []);
 }
 


### PR DESCRIPTION
Follow-up to #78 and the automated review comment: https://github.com/kothic/kothic-js/pull/78#discussion_r3176255477

The clickable layer stored point features per tile key and only cleared that cache when the whole layer was removed. This now follows the GridLayer tile lifecycle:

- register a `tileunload` handler when the clickable layer is added
- delete the unloaded tile key from `_data`
- unregister the tile unload handler on layer removal
- extend the smoke test to cover tile cache eviction and handler cleanup

Validation:
- `npm test`
- `git diff --check`