### PR TITLE
ci: run kothic js tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: JavaScript tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - run: npm install
+
+      - run: npm test


### PR DESCRIPTION
This wires the existing `npm test` suite into GitHub Actions so regressions are visible on pull requests and pushes to `master`.

This is a practical follow-up for #56: the repo now has a smoke-test path from #78/#80, and this makes it run automatically instead of relying on local manual checks.

Validation:
- `npm test`
- `git diff --check`