### PR TITLE
[codex] Add Leaflet tile diagnostics overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ Kothic.render(
 
 `locales` Kothic-JS supports map localization based on name:*lang* tags. Renderer will check all mentioned languages in order of persence.  If object doesn't have localized name, *name* tag will be used.
 
+### Leaflet tile debugging
+
+`L.TileLayer.Kothic` accepts a `debugTiles: true` option. When enabled, each
+tile canvas gets a semi-transparent overlay with the tile `z/x/y`, data URL,
+load status, and rendered feature count. This is useful when a map shows a mix
+of rendered and gray tiles and you need to see whether the JSON tile failed to
+load or rendering completed.
+
+The same events are available from `layer.getDebugMessages()` for tests or
+custom debug panels.
+
 ### Contributing to Kothic JS
 
 Kothic JS is licensed under a BSD license, and we'll be glad to accept your contributions!

--- a/dist/kothic-leaflet.js
+++ b/dist/kothic-leaflet.js
@@ -10,6 +10,7 @@ L.TileLayer.Kothic = L.GridLayer.extend({
                      ' Rendering by <a href="http://github.com/kothic/kothic-js">Kothic JS</a>',
         async: true,
         buffered: false,
+        debugTiles: false,
         styles: MapCSS.availableStyles
     },
 
@@ -21,6 +22,7 @@ L.TileLayer.Kothic = L.GridLayer.extend({
         this._debugMessages = [];
 
         window.onKothicDataResponse = L.Util.bind(this._onKothicDataResponse, this);
+        window.onKothicDataError = L.Util.bind(this._onKothicDataError, this);
     },
 
     _onKothicDataResponse: function(data, zoom, x, y, done) {
@@ -33,7 +35,22 @@ L.TileLayer.Kothic = L.GridLayer.extend({
             return;
         }
 
+        this._debugTile(canvas, {
+            status: 'data loaded',
+            zoom: zoom,
+            x: x,
+            y: y,
+            features: data.features.length
+        });
+
         function onRenderComplete() {
+            this._debugTile(canvas, {
+                status: 'rendered',
+                zoom: zoom,
+                x: x,
+                y: y,
+                features: data.features.length
+            });
             done(error, canvas);
         }
 
@@ -44,10 +61,30 @@ L.TileLayer.Kothic = L.GridLayer.extend({
         Kothic.render(canvas, data, zoom + zoomOffset, {
             styles: styles,
             locales: ['be', 'ru', 'en'],
-            onRenderComplete: onRenderComplete
+            onRenderComplete: L.Util.bind(onRenderComplete, this)
         });
 
         delete this._canvases[key];
+    },
+
+    _onKothicDataError: function(url, zoom, x, y, status, done) {
+        var key = [zoom, x, y].join('/'),
+            canvas = this._canvases[key],
+            error = new Error('Kothic tile data request failed: ' + status + ' ' + url);
+
+        if (!canvas) {
+            return;
+        }
+
+        this._debugTile(canvas, {
+            status: 'data error ' + status,
+            zoom: zoom,
+            x: x,
+            y: y,
+            url: url
+        });
+        delete this._canvases[key];
+        done(error, canvas);
     },
 
     getDebugMessages: function() {
@@ -93,7 +130,57 @@ L.TileLayer.Kothic = L.GridLayer.extend({
                     replace('{y}',tilePoint.y).
                     replace('{z}',rzoom);
         this._canvases[key] = canvas;
+        this._debugTile(canvas, {
+            status: 'loading',
+            zoom: rzoom,
+            x: tilePoint.x,
+            y: tilePoint.y,
+            url: url
+        });
         this._loadJSON(url, rzoom, tilePoint.x, tilePoint.y, done);
+    },
+
+    _debugTile: function(canvas, info) {
+        if (!this.options.debugTiles) {
+            return;
+        }
+
+        this._debugMessages.push(info);
+        this._drawTileDebugOverlay(canvas, info);
+    },
+
+    _drawTileDebugOverlay: function(canvas, info) {
+        var ctx = canvas.getContext && canvas.getContext('2d'),
+            tileId = [info.zoom, info.x, info.y].join('/'),
+            lines = [
+                'Kothic ' + tileId,
+                info.status
+            ],
+            i;
+
+        if (!ctx) {
+            return;
+        }
+
+        if (info.features !== undefined) {
+            lines.push(info.features + ' features');
+        }
+        if (info.url) {
+            lines.push(info.url);
+        }
+
+        ctx.save();
+        ctx.globalAlpha = 0.78;
+        ctx.fillStyle = '#222';
+        ctx.fillRect(4, 4, canvas.width - 8, 18 + lines.length * 14);
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = '#fff';
+        ctx.font = '12px sans-serif';
+        ctx.textBaseline = 'top';
+        for (i = 0; i < lines.length; i++) {
+            ctx.fillText(lines[i], 10, 10 + i * 14);
+        }
+        ctx.restore();
     },
 
     enableStyle: function(name) {
@@ -165,6 +252,7 @@ L.TileLayer.Kothic = L.GridLayer.extend({
                     window.onKothicDataResponse(JSON.parse(xhr.responseText), zoom, x, y, done);
                 } else {
                     console.debug("failed:", url, xhr.status);
+                    window.onKothicDataError(url, zoom, x, y, xhr.status, done);
                 }
             }
         };

--- a/tests/clickable-layer-test.js
+++ b/tests/clickable-layer-test.js
@@ -134,6 +134,41 @@ function createMap(pixel) {
     };
 }
 
+function createDebugCanvas() {
+    var calls = [],
+        ctx = {
+            save: function() {
+                calls.push(['save']);
+            },
+            restore: function() {
+                calls.push(['restore']);
+            },
+            fillRect: function(x, y, width, height) {
+                calls.push(['fillRect', x, y, width, height]);
+            },
+            fillText: function(text, x, y) {
+                calls.push(['fillText', text, x, y]);
+            }
+        };
+
+    return {
+        width: 256,
+        height: 256,
+        calls: calls,
+        getContext: function() {
+            return ctx;
+        }
+    };
+}
+
+function getFilledTexts(canvas) {
+    return canvas.calls.filter(function(call) {
+        return call[0] === 'fillText';
+    }).map(function(call) {
+        return call[1];
+    });
+}
+
 function runTests() {
     var context = createContext(),
         Layer = context.L.TileLayer.Kothic.Clickable,
@@ -227,4 +262,69 @@ function runTests() {
 
 test('clickable Leaflet layer finds nearby point features and cleans up handlers', function() {
     runTests();
+});
+
+function runDebugTileTests() {
+    var context = createContext(),
+        Layer = context.L.TileLayer.Kothic,
+        layer = new Layer('/tiles/{z}/{x}/{y}.json', {
+            debugTiles: true,
+            styles: []
+        }),
+        canvas = createDebugCanvas(),
+        doneArgs = [],
+        texts;
+
+    layer._loadJSON = function(url, zoom, x, y, done) {
+        assert.strictEqual(url, '/tiles/13/2/3.json');
+        assert.strictEqual(zoom, 13);
+        assert.strictEqual(x, 2);
+        assert.strictEqual(y, 3);
+        assert.strictEqual(typeof done, 'function');
+    };
+    layer.drawTile(canvas, {
+        x: 2,
+        y: 3
+    }, 13, function done(error, tile) {
+        doneArgs = [error, tile];
+    });
+
+    assert.strictEqual(layer.getDebugMessages()[0].status, 'loading');
+    assert.strictEqual(layer.getDebugMessages()[0].url, '/tiles/13/2/3.json');
+    texts = getFilledTexts(canvas);
+    assert(texts.indexOf('Kothic 13/2/3') >= 0);
+    assert(texts.indexOf('loading') >= 0);
+
+    context.window.onKothicDataResponse({
+        granularity: 10000,
+        features: []
+    }, 13, 2, 3, function done(error, tile) {
+        doneArgs = [error, tile];
+    });
+
+    assert.strictEqual(doneArgs[0], undefined);
+    assert.strictEqual(doneArgs[1], canvas);
+    assert.strictEqual(layer.getDebugMessages()[1].status, 'data loaded');
+    assert.strictEqual(layer.getDebugMessages()[2].status, 'rendered');
+    texts = getFilledTexts(canvas);
+    assert(texts.indexOf('0 features') >= 0);
+    assert.strictEqual(layer._canvases['13/2/3'], undefined);
+
+    canvas = createDebugCanvas();
+    layer._canvases['13/4/5'] = canvas;
+    context.window.onKothicDataError('/tiles/13/4/5.json', 13, 4, 5, 404, function done(error, tile) {
+        doneArgs = [error, tile];
+    });
+
+    assert.strictEqual(doneArgs[0].message, 'Kothic tile data request failed: 404 /tiles/13/4/5.json');
+    assert.strictEqual(doneArgs[1], canvas);
+    assert.strictEqual(layer.getDebugMessages()[3].status, 'data error 404');
+    texts = getFilledTexts(canvas);
+    assert(texts.indexOf('Kothic 13/4/5') >= 0);
+    assert(texts.indexOf('data error 404') >= 0);
+    assert.strictEqual(layer._canvases['13/4/5'], undefined);
+}
+
+test('debug Leaflet layer reports tile status and failures', function() {
+    runDebugTileTests();
 });


### PR DESCRIPTION
## Summary

- add `debugTiles: true` for `L.TileLayer.Kothic`
- draw a semi-transparent per-tile canvas overlay with `z/x/y`, tile URL, load/render status, and feature count
- keep the same diagnostics available from `layer.getDebugMessages()`
- surface JSON tile load failures through the tile callback so failed tiles can show diagnostics instead of staying silently gray
- cover loading, rendered, and HTTP error diagnostics in the Leaflet layer smoke test

Fixes #16.

## Validation

- npm test
- git diff --check
