### PR TITLE
[codex] Ignore invalid zero dash arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "grunt",
     "lint": "eslint Gruntfile.js src tests debug/kothic-include.js",
     "prepack": "npm run build",
-    "test": "npm run lint && npm run typecheck && npm run build && node --test tests/clickable-layer-test.js tests/render-pixelmatch-test.js",
+    "test": "npm run lint && npm run typecheck && npm run build && node --test tests/clickable-layer-test.js tests/path-dashes-test.js tests/render-pixelmatch-test.js",
     "typecheck": "tsc --noEmit",
     "test:install-browsers": "playwright install chromium"
   }

--- a/src/renderer/path.js
+++ b/src/renderer/path.js
@@ -38,6 +38,23 @@ Kothic.path = (function () {
         return (bp & isTileBoundary(q, size));
     }
 
+    function normalizeDashes(dashes) {
+        var i, value;
+
+        if (!dashes || !dashes.length) {
+            return [];
+        }
+
+        for (i = 0; i < dashes.length; i++) {
+            value = parseFloat(dashes[i]);
+            if (!isFinite(value) || value <= 0) {
+                return [];
+            }
+        }
+
+        return dashes;
+    }
+
     return function (ctx, feature, dashes, fill, ws, hs, granularity) {
         var type = feature.type,
             coords = feature.coordinates;
@@ -70,12 +87,7 @@ Kothic.path = (function () {
 
                         if (j === 0) {
                             ctx.moveTo(screenPoint[0], screenPoint[1]);
-                            if (dashes) {
-                                ctx.setLineDash(dashes);
-                            }
-                            else {
-                                ctx.setLineDash([]);
-                            }
+                            ctx.setLineDash(normalizeDashes(dashes));
                         } else if (!fill && checkSameBoundary(point, prevPoint, granularity)) {
                             ctx.moveTo(screenPoint[0], screenPoint[1]);
                         } else {
@@ -125,12 +137,7 @@ Kothic.path = (function () {
 
                     if (j === 0) {
                         ctx.moveTo(screenPoint[0], screenPoint[1]);
-                        if (dashes) {
-                            ctx.setLineDash(dashes);
-                        }
-                        else {
-                            ctx.setLineDash([]);
-                        }
+                        ctx.setLineDash(normalizeDashes(dashes));
                     } else {
                         ctx.lineTo(screenPoint[0], screenPoint[1]);
                     }

--- a/tests/path-dashes-test.js
+++ b/tests/path-dashes-test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var assert = require('assert'),
+    fs = require('fs'),
+    vm = require('vm');
+
+function createContext() {
+    var context = {
+        isFinite: isFinite,
+        parseFloat: parseFloat,
+        Kothic: {
+            geom: {
+                transformPoint: function(point, ws, hs) {
+                    return [point[0] * ws, point[1] * hs];
+                }
+            }
+        }
+    };
+
+    vm.createContext(context);
+    vm.runInContext(fs.readFileSync('src/renderer/path.js', 'utf8'), context, {
+        filename: 'src/renderer/path.js'
+    });
+    return context;
+}
+
+function createContext2d() {
+    return {
+        dashes: [],
+        moveTo: function() {},
+        lineTo: function() {},
+        setLineDash: function(dashes) {
+            this.dashes.push(dashes);
+        }
+    };
+}
+
+function renderLine(context, dashes) {
+    var ctx = createContext2d();
+
+    context.Kothic.path(ctx, {
+        type: 'LineString',
+        coordinates: [[10, 10], [90, 90]]
+    }, dashes, false, 1, 1, 100);
+
+    return Array.prototype.slice.call(ctx.dashes[0]);
+}
+
+function runTests() {
+    var context = createContext(),
+        valid = [4, 2];
+
+    assert.deepStrictEqual(renderLine(context, [0, 0]), []);
+    assert.deepStrictEqual(renderLine(context, [0, 2]), []);
+    assert.deepStrictEqual(renderLine(context, ['bad', 2]), []);
+    assert.deepStrictEqual(renderLine(context, null), []);
+    assert.deepStrictEqual(renderLine(context, valid), valid);
+}
+
+runTests();


### PR DESCRIPTION
## Summary

- sanitize dash arrays before passing them to canvas `setLineDash`
- treat empty, zero, negative, and non-finite dash segments as a solid line
- add a focused path renderer test for `dashes: 0,0` and related invalid dash values

Fixes #48.

## Validation

- npm test
- git diff --check
