### PR TITLE
[codex] Keep path padding from mutating geometry

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "grunt",
     "lint": "eslint Gruntfile.js src tests debug/kothic-include.js",
     "prepack": "npm run build",
-    "test": "npm run lint && npm run typecheck && npm run build && node --test tests/clickable-layer-test.js tests/path-dashes-test.js tests/render-pixelmatch-test.js",
+    "test": "npm run lint && npm run typecheck && npm run build && node --test tests/clickable-layer-test.js tests/path-coordinate-mutation-test.js tests/path-dashes-test.js tests/render-pixelmatch-test.js",
     "typecheck": "tsc --noEmit",
     "test:install-browsers": "playwright install chromium"
   }

--- a/src/renderer/path.js
+++ b/src/renderer/path.js
@@ -71,7 +71,7 @@ Kothic.path = (function () {
             points,
             len = coords.length,
             len2, pointsLen,
-            prevPoint, point, screenPoint,
+            prevPoint, point, drawPoint, screenPoint,
             dx, dy, dist;
 
         if (type === "MultiPolygon") {
@@ -107,6 +107,7 @@ Kothic.path = (function () {
 
                 for (j = 0; j < pointsLen; j++) {
                     point = points[j];
+                    drawPoint = point;
 
                     // continue path off the tile by some amount to fix path edges between tiles
                     if ((j === 0 || j === pointsLen - 1) && isTileBoundary(point, granularity)) {
@@ -130,10 +131,12 @@ Kothic.path = (function () {
                             break;
                         }
 
-                        point[0] = point[0] + pad * dx / dist;
-                        point[1] = point[1] + pad * dy / dist;
+                        drawPoint = [
+                            point[0] + pad * dx / dist,
+                            point[1] + pad * dy / dist
+                        ];
                     }
-                    screenPoint = Kothic.geom.transformPoint(point, ws, hs);
+                    screenPoint = Kothic.geom.transformPoint(drawPoint, ws, hs);
 
                     if (j === 0) {
                         ctx.moveTo(screenPoint[0], screenPoint[1]);

--- a/tests/path-coordinate-mutation-test.js
+++ b/tests/path-coordinate-mutation-test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var assert = require('assert'),
+    fs = require('fs'),
+    vm = require('vm');
+
+function createContext() {
+    var context = {
+        Math: Math,
+        Kothic: {
+            geom: {
+                transformPoint: function(point, ws, hs) {
+                    return [point[0] * ws, point[1] * hs];
+                }
+            }
+        }
+    };
+
+    vm.createContext(context);
+    vm.runInContext(fs.readFileSync('src/renderer/path.js', 'utf8'), context, {
+        filename: 'src/renderer/path.js'
+    });
+    return context;
+}
+
+function createContext2d() {
+    return {
+        moves: [],
+        lines: [],
+        moveTo: function(x, y) {
+            this.moves.push([x, y]);
+        },
+        lineTo: function(x, y) {
+            this.lines.push([x, y]);
+        },
+        setLineDash: function() {}
+    };
+}
+
+function runTests() {
+    var context = createContext(),
+        ctx = createContext2d(),
+        feature = {
+            type: 'LineString',
+            coordinates: [[0, 50], [100, 50]]
+        };
+
+    context.Kothic.path(ctx, feature, null, false, 1, 1, 100);
+
+    assert.deepStrictEqual(feature.coordinates, [[0, 50], [100, 50]]);
+    assert(ctx.moves[0][0] < 0);
+    assert(ctx.lines[0][0] > 100);
+}
+
+runTests();


### PR DESCRIPTION
## Summary

- stop mutating line coordinates when Kothic extends tile-boundary endpoints for stroke continuity
- keep the out-of-tile padded point local to the canvas path operation
- add a regression test proving tile-boundary padding still draws past the tile edge without changing `feature.coordinates`

Fixes #60.

## Validation

- npm test
- git diff --check
