### PR TITLE
feat(locale): use browser language preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Kothic.render(
 	zoom, // zoom level
 	{
 		onRenderComplete: callback, // (optional) callback to call when rendering is done
-    	styles: ['osmosnimki-maps', 'surface'], // (optional) only specified styles will be rendered, if any
-    	locales: ['be', 'ru', 'en'] // (optional) map languages, see below
+		styles: ['osmosnimki-maps', 'surface'], // (optional) only specified styles will be rendered, if any
+		locales: ['be', 'ru', 'en'] // (optional) map languages, see below
 	});
 ```
 
-`locales` Kothic-JS supports map localization based on name:*lang* tags. Renderer will check all mentioned languages in order of persence.  If object doesn't have localized name, *name* tag will be used.
+`locales` Kothic-JS supports map localization based on name:*lang* tags. Renderer will check all mentioned languages in order of preference. If `locales` is not set, Kothic-JS uses browser language preferences from `navigator.languages` or the older single-language browser fields. If object doesn't have localized name, *name* tag will be used.
 
 ### Contributing to Kothic JS
 

--- a/dist/kothic-leaflet.js
+++ b/dist/kothic-leaflet.js
@@ -43,7 +43,7 @@ L.TileLayer.Kothic = L.GridLayer.extend({
 
         Kothic.render(canvas, data, zoom + zoomOffset, {
             styles: styles,
-            locales: ['be', 'ru', 'en'],
+            locales: this.options.locales,
             onRenderComplete: onRenderComplete
         });
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "grunt",
     "lint": "eslint Gruntfile.js src tests debug/kothic-include.js",
     "prepack": "npm run build",
-    "test": "npm run lint && npm run typecheck && npm run build && node --test tests/clickable-layer-test.js tests/path-dashes-test.js tests/render-pixelmatch-test.js",
+    "test": "npm run lint && npm run typecheck && npm run build && node --test tests/clickable-layer-test.js tests/locales-test.js tests/path-dashes-test.js tests/render-pixelmatch-test.js",
     "typecheck": "tsc --noEmit",
     "test:install-browsers": "playwright install chromium"
   }

--- a/src/kothic.js
+++ b/src/kothic.js
@@ -19,7 +19,7 @@ var Kothic = {
 
         var styles = (options && options.styles) || [];
 
-        MapCSS.locales = (options && options.locales) || [];
+        MapCSS.locales = (options && options.locales) || Kothic.getDefaultLocales();
 
         var devicePixelRatio = Math.max(window.devicePixelRatio || 1, 2);
 
@@ -71,6 +71,47 @@ var Kothic = {
                 //Kothic._renderCollisions(ctx, collisionBuffer.buffer.data);
             });
         });
+    },
+
+    getDefaultLocales: function() {
+        var nav, source, locales = [], seen = {}, i, locale, baseLocale;
+
+        if (typeof window !== 'undefined') {
+            nav = window.navigator;
+        }
+
+        if (!nav) {
+            return [];
+        }
+
+        source = nav.languages || [
+            nav.language ||
+            nav['userLanguage'] ||
+            nav['browserLanguage'] ||
+            nav['systemLanguage']
+        ];
+
+        for (i = 0; i < source.length; i++) {
+            locale = source[i];
+
+            if (!locale) {
+                continue;
+            }
+
+            locale = String(locale).replace('_', '-');
+            if (!seen[locale]) {
+                seen[locale] = true;
+                locales.push(locale);
+            }
+
+            baseLocale = locale.split('-')[0].toLowerCase();
+            if (baseLocale && !seen[baseLocale]) {
+                seen[baseLocale] = true;
+                locales.push(baseLocale);
+            }
+        }
+
+        return locales;
     },
 
     _renderCollisions: function (ctx, node) {

--- a/tests/locales-test.js
+++ b/tests/locales-test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var assert = require('assert'),
+    fs = require('fs'),
+    vm = require('vm');
+
+function createContext(navigatorValue) {
+    var context = {
+        window: {
+            navigator: navigatorValue
+        }
+    };
+
+    vm.createContext(context);
+    vm.runInContext(fs.readFileSync('src/kothic.js', 'utf8'), context, {
+        filename: 'src/kothic.js'
+    });
+    vm.runInContext(fs.readFileSync('src/style/mapcss.js', 'utf8'), context, {
+        filename: 'src/style/mapcss.js'
+    });
+
+    return context;
+}
+
+function runTests() {
+    var context = createContext({
+            languages: ['ru-RU', 'be', 'en_US']
+        }),
+        fallbackContext = createContext({
+            userLanguage: 'de-DE'
+        });
+
+    assert.deepEqual(context.Kothic.getDefaultLocales(), ['ru-RU', 'ru', 'be', 'en-US', 'en']);
+    context.MapCSS.locales = context.Kothic.getDefaultLocales();
+    assert.strictEqual(context.MapCSS.e_localize({
+        name: 'Default',
+        'name:ru': 'Russian',
+        'name:en': 'English'
+    }, 'name'), 'Russian');
+
+    assert.deepEqual(fallbackContext.Kothic.getDefaultLocales(), ['de-DE', 'de']);
+    assert.deepEqual(createContext(null).Kothic.getDefaultLocales(), []);
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- default `Kothic.render()` localization to browser language preferences when `options.locales` is not provided
- preserve explicit `locales` overrides, including Leaflet layer options
- document the default locale behavior and add unit coverage for browser language fallback/order

Fixes #29.

## Validation
- `npm test`
