### PR TITLE
feat(locale): transliterate Cyrillic fallback names

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Kothic.render(
 	});
 ```
 
-`locales` Kothic-JS supports map localization based on name:*lang* tags. Renderer will check all mentioned languages in order of persence.  If object doesn't have localized name, *name* tag will be used.
+`locales` Kothic-JS supports map localization based on name:*lang* tags. Renderer will check all mentioned languages in order of preference. If an English locale is requested and object doesn't have localized name, Cyrillic *name* will be transliterated; otherwise *name* tag will be used.
 
 ### Contributing to Kothic JS
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "grunt",
     "lint": "eslint Gruntfile.js src tests debug/kothic-include.js",
     "prepack": "npm run build",
-    "test": "npm run lint && npm run typecheck && npm run build && node --test tests/clickable-layer-test.js tests/path-dashes-test.js tests/render-pixelmatch-test.js",
+    "test": "npm run lint && npm run typecheck && npm run build && node --test tests/clickable-layer-test.js tests/path-dashes-test.js tests/render-pixelmatch-test.js tests/transliteration-test.js",
     "typecheck": "tsc --noEmit",
     "test:install-browsers": "playwright install chromium"
   }

--- a/src/style/mapcss.js
+++ b/src/style/mapcss.js
@@ -125,16 +125,53 @@ var MapCSS = {
     },
 
     e_localize: function (tags, text) {
-        var locales = MapCSS.locales, i, tag;
+        var locales = MapCSS.locales, i, tag, locale, hasEnglishLocale = false;
 
         for (i = 0; i < locales.length; i++) {
-            tag = text + ':' + locales[i];
+            locale = locales[i];
+            tag = text + ':' + locale;
             if (tags[tag]) {
                 return tags[tag];
             }
+            if (locale === 'en' || String(locale).toLowerCase().indexOf('en-') === 0) {
+                hasEnglishLocale = true;
+            }
+        }
+
+        if (hasEnglishLocale && tags[text]) {
+            return MapCSS.e_transliterate(tags[text]);
         }
 
         return tags[text];
+    },
+
+    e_transliterate: function(text) {
+        var table = {
+                'А': 'A', 'а': 'a', 'Б': 'B', 'б': 'b', 'В': 'V', 'в': 'v',
+                'Г': 'G', 'г': 'g', 'Д': 'D', 'д': 'd', 'Е': 'E', 'е': 'e',
+                'Ё': 'Yo', 'ё': 'yo', 'Ж': 'Zh', 'ж': 'zh', 'З': 'Z', 'з': 'z',
+                'И': 'I', 'и': 'i', 'Й': 'Y', 'й': 'y', 'К': 'K', 'к': 'k',
+                'Л': 'L', 'л': 'l', 'М': 'M', 'м': 'm', 'Н': 'N', 'н': 'n',
+                'О': 'O', 'о': 'o', 'П': 'P', 'п': 'p', 'Р': 'R', 'р': 'r',
+                'С': 'S', 'с': 's', 'Т': 'T', 'т': 't', 'У': 'U', 'у': 'u',
+                'Ф': 'F', 'ф': 'f', 'Х': 'Kh', 'х': 'kh', 'Ц': 'Ts', 'ц': 'ts',
+                'Ч': 'Ch', 'ч': 'ch', 'Ш': 'Sh', 'ш': 'sh', 'Щ': 'Shch', 'щ': 'shch',
+                'Ъ': '', 'ъ': '', 'Ы': 'Y', 'ы': 'y', 'Ь': '', 'ь': '',
+                'Э': 'E', 'э': 'e', 'Ю': 'Yu', 'ю': 'yu', 'Я': 'Ya', 'я': 'ya',
+                'І': 'I', 'і': 'i', 'Ї': 'Yi', 'ї': 'yi', 'Є': 'Ye', 'є': 'ye',
+                'Ґ': 'G', 'ґ': 'g', 'Ў': 'U', 'ў': 'u'
+            },
+            result = '',
+            i, ch;
+
+        text = String(text);
+
+        for (i = 0; i < text.length; i++) {
+            ch = text.charAt(i);
+            result += table.hasOwnProperty(ch) ? table[ch] : ch;
+        }
+
+        return result;
     },
 
     e_join: function () {

--- a/tests/transliteration-test.js
+++ b/tests/transliteration-test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+var assert = require('assert'),
+    fs = require('fs'),
+    vm = require('vm');
+
+function createContext() {
+    var context = {};
+
+    vm.createContext(context);
+    vm.runInContext(fs.readFileSync('src/style/mapcss.js', 'utf8'), context, {
+        filename: 'src/style/mapcss.js'
+    });
+
+    return context;
+}
+
+function runTests() {
+    var context = createContext(),
+        MapCSS = context.MapCSS;
+
+    assert.strictEqual(MapCSS.e_transliterate('Минск'), 'Minsk');
+    assert.strictEqual(MapCSS.e_transliterate('Гомель-Цэнтральны'), 'Gomel-Tsentralny');
+    assert.strictEqual(MapCSS.e_transliterate('Львів'), 'Lviv');
+
+    MapCSS.locales = ['en'];
+    assert.strictEqual(MapCSS.e_localize({
+        name: 'Минск'
+    }, 'name'), 'Minsk');
+
+    MapCSS.locales = ['en-US'];
+    assert.strictEqual(MapCSS.e_localize({
+        name: 'Минск'
+    }, 'name'), 'Minsk');
+
+    MapCSS.locales = ['be', 'en'];
+    assert.strictEqual(MapCSS.e_localize({
+        name: 'Минск',
+        'name:be': 'Мінск'
+    }, 'name'), 'Мінск');
+
+    MapCSS.locales = ['en'];
+    assert.strictEqual(MapCSS.e_localize({
+        name: 'Минск',
+        'name:en': 'Minsk City'
+    }, 'name'), 'Minsk City');
+
+    MapCSS.locales = ['ru'];
+    assert.strictEqual(MapCSS.e_localize({
+        name: 'Минск'
+    }, 'name'), 'Минск');
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- add a Cyrillic-to-Latin `MapCSS.e_transliterate()` helper
- make `MapCSS.e_localize()` transliterate the fallback `name` when an English locale is requested and no English localized tag exists
- add regression coverage for explicit localized names, English fallback transliteration, and non-English fallback behavior

Fixes #30.

## Validation
- `npm test`
