### PR TITLE
feat(text): support label width and underline

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "grunt",
     "lint": "eslint Gruntfile.js src tests debug/kothic-include.js",
     "prepack": "npm run build",
-    "test": "npm run lint && npm run typecheck && npm run build && node --test tests/clickable-layer-test.js tests/path-dashes-test.js tests/render-pixelmatch-test.js",
+    "test": "npm run lint && npm run typecheck && npm run build && node --test tests/clickable-layer-test.js tests/path-dashes-test.js tests/render-pixelmatch-test.js tests/text-label-properties-test.js",
     "typecheck": "tsc --noEmit",
     "test:install-browsers": "playwright install chromium"
   }

--- a/src/renderer/texticons.js
+++ b/src/renderer/texticons.js
@@ -66,21 +66,45 @@ Kothic.texticons = {
             }
 
             if (feature.type === 'Polygon' || feature.type === 'Point') {
-                var textWidth = ctx.measureText(text).width,
-                        letterWidth = textWidth / text.length,
-                        collisionWidth = textWidth,
-                        collisionHeight = letterWidth * 2.5,
-                        offset = style['text-offset'] || 0;
+                var maxWidth = parseFloat(style['max-width']) || 0,
+                        lines = Kothic.texticons.wrapText(ctx, text, maxWidth),
+                        fontSize = parseFloat(style['font-size']) || 9,
+                        lineHeight = fontSize * 1.2,
+                        textWidths = [],
+                        textWidth = 0,
+                        collisionWidth,
+                        collisionHeight,
+                        offset = style['text-offset'] || 0,
+                        textY,
+                        i;
+
+                for (i = 0; i < lines.length; i++) {
+                    textWidths[i] = ctx.measureText(lines[i]).width;
+                    textWidth = Math.max(textWidth, textWidths[i]);
+                }
+
+                collisionWidth = textWidth;
+                collisionHeight = lineHeight * lines.length;
 
                 if ((style['text-allow-overlap'] !== 'true') &&
                         collides.checkPointWH([point[0], point[1] + offset], collisionWidth, collisionHeight, feature.kothicId)) {
                     return;
                 }
 
-                if (halo) {
-                    ctx.strokeText(text, point[0], point[1] + offset);
+                textY = point[1] + offset - lineHeight * (lines.length - 1) / 2;
+
+                for (i = 0; i < lines.length; i++) {
+                    if (halo) {
+                        ctx.strokeText(lines[i], point[0], textY);
+                    }
+                    ctx.fillText(lines[i], point[0], textY);
+
+                    if (style['text-decoration'] === 'underline') {
+                        ctx.fillRect(point[0] - textWidths[i] / 2, textY + fontSize / 2, textWidths[i], Math.max(1, fontSize / 12));
+                    }
+
+                    textY += lineHeight;
                 }
-                ctx.fillText(text, point[0], point[1] + offset);
 
                 var padding = style['-x-kot-min-distance'] || 20;
                 collides.addPointWH([point[0], point[1] + offset], collisionWidth, collisionHeight, padding, feature.kothicId);
@@ -100,5 +124,32 @@ Kothic.texticons = {
             var padding2 = parseFloat(style['-x-kot-min-distance']) || 0;
             collides.addPointWH(point, w, h, padding2, feature.kothicId);
         }
+    },
+
+    wrapText: function(ctx, text, maxWidth) {
+        var words, lines = [], line = '', nextLine, i;
+
+        if (!maxWidth || ctx.measureText(text).width <= maxWidth) {
+            return [text];
+        }
+
+        words = text.split(/\s+/);
+
+        for (i = 0; i < words.length; i++) {
+            nextLine = line ? line + ' ' + words[i] : words[i];
+
+            if (line && ctx.measureText(nextLine).width > maxWidth) {
+                lines.push(line);
+                line = words[i];
+            } else {
+                line = nextLine;
+            }
+        }
+
+        if (line) {
+            lines.push(line);
+        }
+
+        return lines;
     }
 };

--- a/tests/text-label-properties-test.js
+++ b/tests/text-label-properties-test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+var assert = require('assert'),
+    fs = require('fs'),
+    vm = require('vm');
+
+function createContext() {
+    var context = {
+        MapCSS: {},
+        Kothic: {
+            geom: {
+                getReprPoint: function(feature) {
+                    return feature.coordinates;
+                },
+                transformPoint: function(point, ws, hs) {
+                    return [point[0] * ws, point[1] * hs];
+                }
+            }
+        }
+    };
+
+    vm.createContext(context);
+    [
+        'src/style/style.js',
+        'src/renderer/texticons.js'
+    ].forEach(function(file) {
+        vm.runInContext(fs.readFileSync(file, 'utf8'), context, {
+            filename: file
+        });
+    });
+
+    return context;
+}
+
+function createContext2d() {
+    return {
+        fillTexts: [],
+        fillRects: [],
+        measureText: function(text) {
+            return {
+                width: text.length * 5
+            };
+        },
+        fillText: function(text, x, y) {
+            this.fillTexts.push([text, x, y]);
+        },
+        strokeText: function() {},
+        fillRect: function(x, y, width, height) {
+            this.fillRects.push([x, y, width, height]);
+        }
+    };
+}
+
+function createCollisionBuffer() {
+    return {
+        boxes: [],
+        checkPointWH: function() {
+            return false;
+        },
+        addPointWH: function(point, width, height, padding, id) {
+            this.boxes.push([point, width, height, padding, id]);
+        }
+    };
+}
+
+function runTests() {
+    var context = createContext(),
+        ctx = createContext2d(),
+        collisions = createCollisionBuffer();
+
+    context.Kothic.texticons.render(ctx, {
+        kothicId: 1,
+        type: 'Point',
+        coordinates: [50, 50],
+        style: {
+            text: 'Old Town Hall',
+            'font-size': 10,
+            'max-width': 45,
+            'text-decoration': 'underline'
+        }
+    }, collisions, 1, 1, true, false);
+
+    assert.deepStrictEqual(ctx.fillTexts.map(function(call) {
+        return call[0];
+    }), ['Old Town', 'Hall']);
+    assert.strictEqual(ctx.fillRects.length, 2);
+    assert.strictEqual(ctx.fillRects[0][2], 40);
+    assert.strictEqual(ctx.fillRects[1][2], 20);
+    assert.strictEqual(collisions.boxes[0][1], 40);
+    assert.strictEqual(collisions.boxes[0][2], 24);
+    assert.deepEqual(context.Kothic.texticons.wrapText(ctx, 'Short', 45), ['Short']);
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- add runtime support for `max-width` wrapping on point and polygon text labels
- add runtime support for `text-decoration: underline`
- keep existing text rendering behavior unchanged when those label properties are not set

Part of #9.

## Validation
- `npm test`
