### PR TITLE
feat(text): render labels on multilinestrings

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "grunt",
     "lint": "eslint Gruntfile.js src tests debug/kothic-include.js",
     "prepack": "npm run build",
-    "test": "npm run lint && npm run typecheck && npm run build && node --test tests/clickable-layer-test.js tests/path-dashes-test.js tests/render-pixelmatch-test.js",
+    "test": "npm run lint && npm run typecheck && npm run build && node --test tests/clickable-layer-test.js tests/multilinestring-text-test.js tests/path-dashes-test.js tests/render-pixelmatch-test.js",
     "typecheck": "tsc --noEmit",
     "test:install-browsers": "playwright install chromium"
   }

--- a/src/renderer/text.js
+++ b/src/renderer/text.js
@@ -62,7 +62,7 @@ Kothic.textOnPath = (function () {
                 pathLen = Kothic.geom.getPolyLength(points);
 
         if (pathLen < textWidth) {
-            return;  // if label won't fit - don't try to
+            return false;  // if label won't fit - don't try to
         }
 
         var avgLetterWidth = getWidth(ctx, 'a');
@@ -166,7 +166,7 @@ Kothic.textOnPath = (function () {
             }
 
             if (solution >= 2) {
-                return;
+                return false;
             }
 
             if (positions.length > 0) {
@@ -185,5 +185,7 @@ Kothic.textOnPath = (function () {
             renderText(ctx, axy);
             addCollision(collisions, ctx, axy[4], axy, avgLetterWidth);
         }
+
+        return true;
     };
 }());

--- a/src/renderer/texticons.js
+++ b/src/renderer/texticons.js
@@ -4,7 +4,7 @@ Kothic.texticons = {
     render: function (ctx, feature, collides, ws, hs, renderText, renderIcon) {
         var style = feature.style, img, point, w, h;
 
-        if (renderIcon || (renderText && feature.type !== 'LineString')) {
+        if (renderIcon || (renderText && feature.type !== 'LineString' && feature.type !== 'MultiLineString')) {
             var reprPoint = Kothic.geom.getReprPoint(feature);
             if (!reprPoint) {
                 return;
@@ -89,6 +89,15 @@ Kothic.texticons = {
 
                 var points = Kothic.geom.transformPoints(feature.coordinates, ws, hs);
                 Kothic.textOnPath(ctx, points, text, halo, collides);
+            } else if (feature.type === 'MultiLineString') {
+                var i, linesLen;
+
+                for (i = 0, linesLen = feature.coordinates.length; i < linesLen; i++) {
+                    points = Kothic.geom.transformPoints(feature.coordinates[i], ws, hs);
+                    if (Kothic.textOnPath(ctx, points, text, halo, collides)) {
+                        break;
+                    }
+                }
             }
         }
 

--- a/tests/multilinestring-text-test.js
+++ b/tests/multilinestring-text-test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+var assert = require('assert'),
+    fs = require('fs'),
+    vm = require('vm');
+
+function createContext() {
+    var context = {
+        Math: Math,
+        MapCSS: {},
+        Kothic: {}
+    };
+
+    vm.createContext(context);
+    [
+        'src/utils/geom.js',
+        'src/style/style.js',
+        'src/renderer/text.js',
+        'src/renderer/texticons.js'
+    ].forEach(function(file) {
+        vm.runInContext(fs.readFileSync(file, 'utf8'), context, {
+            filename: file
+        });
+    });
+
+    return context;
+}
+
+function createContext2d() {
+    return {
+        texts: [],
+        measureText: function(text) {
+            return {
+                width: text.length * 10
+            };
+        },
+        translate: function() {},
+        rotate: function() {},
+        fillText: function(text) {
+            this.texts.push(text);
+        },
+        strokeText: function() {}
+    };
+}
+
+function createCollisionBuffer() {
+    return {
+        checkPointWH: function() {
+            return false;
+        },
+        addPoints: function() {},
+        addPointWH: function() {}
+    };
+}
+
+function runTests() {
+    var context = createContext(),
+        ctx = createContext2d();
+
+    assert.strictEqual(context.Kothic.textOnPath(ctx, [[0, 0], [10, 0]], 'Long label', false, createCollisionBuffer()), false);
+
+    context.Kothic.texticons.render(ctx, {
+        kothicId: 1,
+        type: 'MultiLineString',
+        coordinates: [
+            [[0, 0], [10, 0]],
+            [[0, 50], [200, 50]]
+        ],
+        style: {
+            text: 'Main Road'
+        }
+    }, createCollisionBuffer(), 1, 1, true, false);
+
+    assert.deepStrictEqual(ctx.texts, ['Main Road']);
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- make `Kothic.textOnPath()` report whether a label was actually placed
- render text labels for `MultiLineString` features by trying each line until one can fit the label
- add regression coverage for skipped short lines and successful MultiLineString label placement

Part of #20.

## Validation
- `npm test`
