### PR TITLE
feat(text): honor centered line labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "grunt",
     "lint": "eslint Gruntfile.js src tests debug/kothic-include.js",
     "prepack": "npm run build",
-    "test": "npm run lint && npm run typecheck && npm run build && node --test tests/clickable-layer-test.js tests/path-dashes-test.js tests/render-pixelmatch-test.js",
+    "test": "npm run lint && npm run typecheck && npm run build && node --test tests/clickable-layer-test.js tests/path-dashes-test.js tests/render-pixelmatch-test.js tests/text-position-center-test.js",
     "typecheck": "tsc --noEmit",
     "test:install-browsers": "playwright install chromium"
   }

--- a/src/renderer/texticons.js
+++ b/src/renderer/texticons.js
@@ -2,9 +2,10 @@
 Kothic.texticons = {
 
     render: function (ctx, feature, collides, ws, hs, renderText, renderIcon) {
-        var style = feature.style, img, point, w, h;
+        var style = feature.style, img, point, w, h,
+            centeredText = style['text-position'] === 'center';
 
-        if (renderIcon || (renderText && feature.type !== 'LineString')) {
+        if (renderIcon || (renderText && (feature.type !== 'LineString' || centeredText))) {
             var reprPoint = Kothic.geom.getReprPoint(feature);
             if (!reprPoint) {
                 return;
@@ -65,7 +66,7 @@ Kothic.texticons = {
                 text = text.replace(/(^|\s)\S/g, function(ch) { return ch.toUpperCase(); });
             }
 
-            if (feature.type === 'Polygon' || feature.type === 'Point') {
+            if (feature.type === 'Polygon' || feature.type === 'Point' || centeredText) {
                 var textWidth = ctx.measureText(text).width,
                         letterWidth = textWidth / text.length,
                         collisionWidth = textWidth,

--- a/tests/text-position-center-test.js
+++ b/tests/text-position-center-test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+var assert = require('assert'),
+    fs = require('fs'),
+    vm = require('vm');
+
+function createContext() {
+    var context = {
+        Math: Math,
+        MapCSS: {},
+        Kothic: {}
+    };
+
+    vm.createContext(context);
+    [
+        'src/utils/geom.js',
+        'src/style/style.js',
+        'src/renderer/text.js',
+        'src/renderer/texticons.js'
+    ].forEach(function(file) {
+        vm.runInContext(fs.readFileSync(file, 'utf8'), context, {
+            filename: file
+        });
+    });
+
+    return context;
+}
+
+function createContext2d() {
+    return {
+        fillTexts: [],
+        pathTexts: [],
+        transformed: false,
+        measureText: function(text) {
+            return {
+                width: text.length * 5
+            };
+        },
+        fillText: function(text, x, y) {
+            if (this.transformed) {
+                this.pathTexts.push(text);
+            } else {
+                this.fillTexts.push([text, x, y]);
+            }
+        },
+        strokeText: function() {},
+        translate: function(x, y) {
+            if (x || y) {
+                this.transformed = true;
+            }
+        },
+        rotate: function(angle) {
+            if (angle) {
+                this.transformed = true;
+            }
+        }
+    };
+}
+
+function createCollisionBuffer() {
+    return {
+        checkPointWH: function() {
+            return false;
+        },
+        addPointWH: function() {},
+        addPoints: function() {}
+    };
+}
+
+function renderLine(context, style) {
+    var ctx = createContext2d();
+
+    context.Kothic.texticons.render(ctx, {
+        kothicId: 1,
+        type: 'LineString',
+        coordinates: [[0, 0], [100, 0]],
+        style: style
+    }, createCollisionBuffer(), 1, 1, true, false);
+
+    return ctx;
+}
+
+function runTests() {
+    var context = createContext(),
+        centered = renderLine(context, {
+            text: 'Center',
+            'text-position': 'center'
+        }),
+        along = renderLine(context, {
+            text: 'Along'
+        });
+
+    assert.deepStrictEqual(centered.fillTexts, [['Center', 50, 0]]);
+    assert.deepStrictEqual(centered.pathTexts, []);
+    assert.deepStrictEqual(along.fillTexts, []);
+    assert.deepStrictEqual(along.pathTexts, ['Along']);
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- honor `text-position: center` for `LineString` labels
- keep existing text-on-path behavior for line labels without that property
- add regression coverage for centered-vs-path line label rendering

Part of #9.

## Validation
- `npm test`
